### PR TITLE
Correct artist name

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -69,10 +69,10 @@
 		<meta property="se:url.authority.nacoaf" refines="#author">http://id.loc.gov/authorities/names/no96026845</meta>
 		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>
 		<meta property="role" refines="#author" scheme="marc:relators">ann</meta>
-		<dc:contributor id="artist">William van de Velde the Younger</dc:contributor>
-		<meta property="file-as" refines="#artist">van de Velde, William (the Younger)</meta>
-		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://en.wikipedia.org/wiki/Willem_van_de_Velde_the_Younger</meta>
-		<meta property="se:url.authority.nacoaf" refines="#artist">http://id.loc.gov/authorities/names/n82056731</meta>
+		<dc:contributor id="artist">Johan Barthold Jongkind</dc:contributor>
+		<meta property="file-as" refines="#artist">Jongkind, Johan Barthold</meta>
+		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://en.wikipedia.org/wiki/Johan_Jongkind</meta>
+		<meta property="se:url.authority.nacoaf" refines="#artist">http://id.loc.gov/authorities/names/n50038617</meta>
 		<meta property="role" refines="#artist" scheme="marc:relators">art</meta>
 		<dc:contributor id="transcriber-1">Wikisource</dc:contributor>
 		<meta property="file-as" refines="#transcriber-1">Wikisource</meta>


### PR DESCRIPTION
It's correct in colophon.xhtml

It looks like the artist name got swapped this the content.opf in this repo:

alexandre-dumas_the-count-of-monte-cristo_chapman-and-hall